### PR TITLE
Fix cookie banner & analytics

### DIFF
--- a/articles/ab-test.html
+++ b/articles/ab-test.html
@@ -38,6 +38,48 @@
     <link href="../css/style.css" rel="stylesheet">
     <!-- Flag Icons CSS -->
     <link href="../css/flags.css" rel="stylesheet">
+    <!-- Iubenda Cookie Banner Configuration -->
+    <script type="text/javascript">
+        function getSelectedLanguage() {
+            var storedLang = localStorage.getItem('selectedLanguage');
+            if (storedLang) return storedLang;
+            if (typeof i18next !== 'undefined' && i18next.language) return i18next.language;
+            return 'it';
+        }
+
+        var _iub = _iub || [];
+        _iub.csConfiguration = {
+            cookiePolicyId: 16452539,
+            siteId: 4019868,
+            lang: getSelectedLanguage(),
+            countryDetection: true,
+            enableLgpd: true,
+            enableUspr: true,
+            googleConsentMode: true,
+            googleTagManager: { containerId: 'GTM-PXVN2GTW' },
+            googleAnalytics: { measurementId: 'G-50TEXSN8V2' },
+            banner: {
+                acceptButtonDisplay: true,
+                customizeButtonDisplay: true,
+                position: "float-bottom-center",
+                rejectButtonDisplay: true
+            }
+        };
+
+        document.addEventListener('DOMContentLoaded', function() {
+            if (typeof i18next !== 'undefined') {
+                i18next.on('languageChanged', function(lang) {
+                    if (_iub.csConfiguration) {
+                        _iub.csConfiguration.lang = lang;
+                        if (typeof _iub.cs !== 'undefined' && typeof _iub.cs.reload === 'function') {
+                            _iub.cs.reload();
+                        }
+                    }
+                });
+            }
+        });
+    </script>
+    <script type="text/javascript" src="//cdn.iubenda.com/cs/iubenda_cs.js" charset="UTF-8" async></script>
     <style>
         .article-header {
             background-color: #6f42c1;

--- a/articles/aida-model.html
+++ b/articles/aida-model.html
@@ -38,6 +38,48 @@
     <link href="../css/style.css" rel="stylesheet">
     <!-- Flag Icons CSS -->
     <link href="../css/flags.css" rel="stylesheet">
+    <!-- Iubenda Cookie Banner Configuration -->
+    <script type="text/javascript">
+        function getSelectedLanguage() {
+            var storedLang = localStorage.getItem('selectedLanguage');
+            if (storedLang) return storedLang;
+            if (typeof i18next !== 'undefined' && i18next.language) return i18next.language;
+            return 'it';
+        }
+
+        var _iub = _iub || [];
+        _iub.csConfiguration = {
+            cookiePolicyId: 16452539,
+            siteId: 4019868,
+            lang: getSelectedLanguage(),
+            countryDetection: true,
+            enableLgpd: true,
+            enableUspr: true,
+            googleConsentMode: true,
+            googleTagManager: { containerId: 'GTM-PXVN2GTW' },
+            googleAnalytics: { measurementId: 'G-50TEXSN8V2' },
+            banner: {
+                acceptButtonDisplay: true,
+                customizeButtonDisplay: true,
+                position: "float-bottom-center",
+                rejectButtonDisplay: true
+            }
+        };
+
+        document.addEventListener('DOMContentLoaded', function() {
+            if (typeof i18next !== 'undefined') {
+                i18next.on('languageChanged', function(lang) {
+                    if (_iub.csConfiguration) {
+                        _iub.csConfiguration.lang = lang;
+                        if (typeof _iub.cs !== 'undefined' && typeof _iub.cs.reload === 'function') {
+                            _iub.cs.reload();
+                        }
+                    }
+                });
+            }
+        });
+    </script>
+    <script type="text/javascript" src="//cdn.iubenda.com/cs/iubenda_cs.js" charset="UTF-8" async></script>
     <style>
         .article-header {
             background-color: #fd7e14;

--- a/articles/article-template.html
+++ b/articles/article-template.html
@@ -38,6 +38,48 @@
     <link href="../css/style.css" rel="stylesheet">
     <!-- Flag Icons CSS -->
     <link href="../css/flags.css" rel="stylesheet">
+    <!-- Iubenda Cookie Banner Configuration -->
+    <script type="text/javascript">
+        function getSelectedLanguage() {
+            var storedLang = localStorage.getItem('selectedLanguage');
+            if (storedLang) return storedLang;
+            if (typeof i18next !== 'undefined' && i18next.language) return i18next.language;
+            return 'it';
+        }
+
+        var _iub = _iub || [];
+        _iub.csConfiguration = {
+            cookiePolicyId: 16452539,
+            siteId: 4019868,
+            lang: getSelectedLanguage(),
+            countryDetection: true,
+            enableLgpd: true,
+            enableUspr: true,
+            googleConsentMode: true,
+            googleTagManager: { containerId: 'GTM-PXVN2GTW' },
+            googleAnalytics: { measurementId: 'G-50TEXSN8V2' },
+            banner: {
+                acceptButtonDisplay: true,
+                customizeButtonDisplay: true,
+                position: "float-bottom-center",
+                rejectButtonDisplay: true
+            }
+        };
+
+        document.addEventListener('DOMContentLoaded', function() {
+            if (typeof i18next !== 'undefined') {
+                i18next.on('languageChanged', function(lang) {
+                    if (_iub.csConfiguration) {
+                        _iub.csConfiguration.lang = lang;
+                        if (typeof _iub.cs !== 'undefined' && typeof _iub.cs.reload === 'function') {
+                            _iub.cs.reload();
+                        }
+                    }
+                });
+            }
+        });
+    </script>
+    <script type="text/javascript" src="//cdn.iubenda.com/cs/iubenda_cs.js" charset="UTF-8" async></script>
 </head>
 <body>
     <!-- Navbar -->

--- a/articles/credit-cards.html
+++ b/articles/credit-cards.html
@@ -38,6 +38,48 @@
     <link href="../css/style.css" rel="stylesheet">
     <!-- Flag Icons CSS -->
     <link href="../css/flags.css" rel="stylesheet">
+    <!-- Iubenda Cookie Banner Configuration -->
+    <script type="text/javascript">
+        function getSelectedLanguage() {
+            var storedLang = localStorage.getItem('selectedLanguage');
+            if (storedLang) return storedLang;
+            if (typeof i18next !== 'undefined' && i18next.language) return i18next.language;
+            return 'it';
+        }
+
+        var _iub = _iub || [];
+        _iub.csConfiguration = {
+            cookiePolicyId: 16452539,
+            siteId: 4019868,
+            lang: getSelectedLanguage(),
+            countryDetection: true,
+            enableLgpd: true,
+            enableUspr: true,
+            googleConsentMode: true,
+            googleTagManager: { containerId: 'GTM-PXVN2GTW' },
+            googleAnalytics: { measurementId: 'G-50TEXSN8V2' },
+            banner: {
+                acceptButtonDisplay: true,
+                customizeButtonDisplay: true,
+                position: "float-bottom-center",
+                rejectButtonDisplay: true
+            }
+        };
+
+        document.addEventListener('DOMContentLoaded', function() {
+            if (typeof i18next !== 'undefined') {
+                i18next.on('languageChanged', function(lang) {
+                    if (_iub.csConfiguration) {
+                        _iub.csConfiguration.lang = lang;
+                        if (typeof _iub.cs !== 'undefined' && typeof _iub.cs.reload === 'function') {
+                            _iub.cs.reload();
+                        }
+                    }
+                });
+            }
+        });
+    </script>
+    <script type="text/javascript" src="//cdn.iubenda.com/cs/iubenda_cs.js" charset="UTF-8" async></script>
     <style>
         .article-header {
             background-color: #0d6efd;

--- a/articles/duolingo-case.html
+++ b/articles/duolingo-case.html
@@ -38,6 +38,48 @@
     <link href="../css/style.css" rel="stylesheet">
     <!-- Flag Icons CSS -->
     <link href="../css/flags.css" rel="stylesheet">
+    <!-- Iubenda Cookie Banner Configuration -->
+    <script type="text/javascript">
+        function getSelectedLanguage() {
+            var storedLang = localStorage.getItem('selectedLanguage');
+            if (storedLang) return storedLang;
+            if (typeof i18next !== 'undefined' && i18next.language) return i18next.language;
+            return 'it';
+        }
+
+        var _iub = _iub || [];
+        _iub.csConfiguration = {
+            cookiePolicyId: 16452539,
+            siteId: 4019868,
+            lang: getSelectedLanguage(),
+            countryDetection: true,
+            enableLgpd: true,
+            enableUspr: true,
+            googleConsentMode: true,
+            googleTagManager: { containerId: 'GTM-PXVN2GTW' },
+            googleAnalytics: { measurementId: 'G-50TEXSN8V2' },
+            banner: {
+                acceptButtonDisplay: true,
+                customizeButtonDisplay: true,
+                position: "float-bottom-center",
+                rejectButtonDisplay: true
+            }
+        };
+
+        document.addEventListener('DOMContentLoaded', function() {
+            if (typeof i18next !== 'undefined') {
+                i18next.on('languageChanged', function(lang) {
+                    if (_iub.csConfiguration) {
+                        _iub.csConfiguration.lang = lang;
+                        if (typeof _iub.cs !== 'undefined' && typeof _iub.cs.reload === 'function') {
+                            _iub.cs.reload();
+                        }
+                    }
+                });
+            }
+        });
+    </script>
+    <script type="text/javascript" src="//cdn.iubenda.com/cs/iubenda_cs.js" charset="UTF-8" async></script>
     <style>
         .article-header {
             background-color: #20c997;

--- a/articles/marketing-glossary.html
+++ b/articles/marketing-glossary.html
@@ -38,6 +38,48 @@
     <link href="../css/style.css" rel="stylesheet">
     <!-- Flag Icons CSS -->
     <link href="../css/flags.css" rel="stylesheet">
+    <!-- Iubenda Cookie Banner Configuration -->
+    <script type="text/javascript">
+        function getSelectedLanguage() {
+            var storedLang = localStorage.getItem('selectedLanguage');
+            if (storedLang) return storedLang;
+            if (typeof i18next !== 'undefined' && i18next.language) return i18next.language;
+            return 'it';
+        }
+
+        var _iub = _iub || [];
+        _iub.csConfiguration = {
+            cookiePolicyId: 16452539,
+            siteId: 4019868,
+            lang: getSelectedLanguage(),
+            countryDetection: true,
+            enableLgpd: true,
+            enableUspr: true,
+            googleConsentMode: true,
+            googleTagManager: { containerId: 'GTM-PXVN2GTW' },
+            googleAnalytics: { measurementId: 'G-50TEXSN8V2' },
+            banner: {
+                acceptButtonDisplay: true,
+                customizeButtonDisplay: true,
+                position: "float-bottom-center",
+                rejectButtonDisplay: true
+            }
+        };
+
+        document.addEventListener('DOMContentLoaded', function() {
+            if (typeof i18next !== 'undefined') {
+                i18next.on('languageChanged', function(lang) {
+                    if (_iub.csConfiguration) {
+                        _iub.csConfiguration.lang = lang;
+                        if (typeof _iub.cs !== 'undefined' && typeof _iub.cs.reload === 'function') {
+                            _iub.cs.reload();
+                        }
+                    }
+                });
+            }
+        });
+    </script>
+    <script type="text/javascript" src="//cdn.iubenda.com/cs/iubenda_cs.js" charset="UTF-8" async></script>
     <style>
         .article-header {
             background-color: #0dcaf0;

--- a/index.html
+++ b/index.html
@@ -58,12 +58,15 @@
 
         var _iub = _iub || [];
         _iub.csConfiguration = {
-            cookiePolicyId: 16452539, // Replace with your actual Iubenda Cookie Policy ID
-            siteId: 4019868, // Replace with your actual Iubenda Site ID
+            cookiePolicyId: 16452539,
+            siteId: 4019868,
             lang: getSelectedLanguage(),
             countryDetection: true,
             enableLgpd: true,
             enableUspr: true,
+            googleConsentMode: true,
+            googleTagManager: { containerId: 'GTM-PXVN2GTW' },
+            googleAnalytics: { measurementId: 'G-50TEXSN8V2' },
             banner: {
                 acceptButtonDisplay: true,
                 customizeButtonDisplay: true,


### PR DESCRIPTION
## Summary
- integrate Iubenda cookie banner with Google Tag Manager and Analytics
- add the integration snippet to each article

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68552c86a7b8832e81b7397469b36501