### PR TITLE
Add lang attributes and sync i18n

### DIFF
--- a/articles/ab-test.html
+++ b/articles/ab-test.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="it">
 <head>
 
     <!-- Analytics and Tag Manager will be loaded after consent -->

--- a/articles/aida-model.html
+++ b/articles/aida-model.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="it">
 <head>
 
     <!-- Analytics and Tag Manager will be loaded after consent -->

--- a/articles/article-template.html
+++ b/articles/article-template.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="it">
 <head>
 
     <!-- Analytics and Tag Manager will be loaded after consent -->

--- a/articles/credit-cards.html
+++ b/articles/credit-cards.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="it">
 <head>
 
     <!-- Analytics and Tag Manager will be loaded after consent -->

--- a/articles/duolingo-case.html
+++ b/articles/duolingo-case.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="it">
 <head>
 
     <!-- Analytics and Tag Manager will be loaded after consent -->

--- a/articles/marketing-glossary.html
+++ b/articles/marketing-glossary.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="it">
 <head>
 
     <!-- Analytics and Tag Manager will be loaded after consent -->

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="it">
 <head>
 
     <!-- Analytics and Tag Manager will be loaded after consent -->

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -105,6 +105,11 @@ document.addEventListener('DOMContentLoaded', function() {
           useOptionsAttr: true
         });
 
+        // Keep the <html> lang attribute in sync with the active language
+        i18next.on('languageChanged', function(lng) {
+          document.documentElement.lang = lng;
+        });
+
         // Check if language is already set in localStorage
         const savedLanguage = localStorage.getItem('selectedLanguage');
 


### PR DESCRIPTION
## Summary
- mark all HTML files with `lang="it"`
- keep the `<html>` `lang` attribute updated when language changes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855900d47a4832e8e7cd964fa624688