### PR TITLE
Add default Iubenda URLs

### DIFF
--- a/articles/ab-test.html
+++ b/articles/ab-test.html
@@ -440,8 +440,8 @@
                         <li class="mb-3"><a href="../index.html#articles" class="text-white text-decoration-none"><i class="bi bi-file-text me-2"></i><span data-i18n="navbar.articles">Articoli</span></a></li>
                         <li class="mb-3"><a href="../index.html#educational-materials" class="text-white text-decoration-none"><i class="bi bi-file-earmark-arrow-down me-2"></i><span data-i18n="educationalMaterials.title">Materiale Didattico</span></a></li>
                         <li class="mb-3"><a href="../index.html#newsletter" class="text-white text-decoration-none"><i class="bi bi-envelope me-2"></i><span data-i18n="navbar.newsletter">Newsletter</span></a></li>
-                        <li class="mb-3"><a href="#" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Privacy Policy"><i class="bi bi-shield-lock me-2"></i><span data-i18n="footer.privacyPolicy">Privacy Policy</span></a></li>
-                        <li class="mb-3"><a href="#" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Cookie Policy"><i class="bi bi-cookie me-2"></i><span data-i18n="footer.cookiePolicy">Cookie Policy</span></a></li>
+                        <li class="mb-3"><a href="https://www.iubenda.com/privacy-policy/" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Privacy Policy"><i class="bi bi-shield-lock me-2"></i><span data-i18n="footer.privacyPolicy">Privacy Policy</span></a></li>
+                        <li class="mb-3"><a href="https://www.iubenda.com/privacy-policy/cookie-policy" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Cookie Policy"><i class="bi bi-cookie me-2"></i><span data-i18n="footer.cookiePolicy">Cookie Policy</span></a></li>
                     </ul>
                 </div>
                 <div class="col-md-4">

--- a/articles/aida-model.html
+++ b/articles/aida-model.html
@@ -494,8 +494,8 @@
                         <li class="mb-3"><a href="../index.html#articles" class="text-white text-decoration-none"><i class="bi bi-file-text me-2"></i><span data-i18n="navbar.articles">Articoli</span></a></li>
                         <li class="mb-3"><a href="../index.html#educational-materials" class="text-white text-decoration-none"><i class="bi bi-file-earmark-arrow-down me-2"></i><span data-i18n="educationalMaterials.title">Materiale Didattico</span></a></li>
                         <li class="mb-3"><a href="../index.html#newsletter" class="text-white text-decoration-none"><i class="bi bi-envelope me-2"></i><span data-i18n="navbar.newsletter">Newsletter</span></a></li>
-                        <li class="mb-3"><a href="#" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Privacy Policy"><i class="bi bi-shield-lock me-2"></i><span data-i18n="footer.privacyPolicy">Privacy Policy</span></a></li>
-                        <li class="mb-3"><a href="#" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Cookie Policy"><i class="bi bi-cookie me-2"></i><span data-i18n="footer.cookiePolicy">Cookie Policy</span></a></li>
+                        <li class="mb-3"><a href="https://www.iubenda.com/privacy-policy/" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Privacy Policy"><i class="bi bi-shield-lock me-2"></i><span data-i18n="footer.privacyPolicy">Privacy Policy</span></a></li>
+                        <li class="mb-3"><a href="https://www.iubenda.com/privacy-policy/cookie-policy" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Cookie Policy"><i class="bi bi-cookie me-2"></i><span data-i18n="footer.cookiePolicy">Cookie Policy</span></a></li>
                     </ul>
                 </div>
                 <div class="col-md-4">

--- a/articles/article-template.html
+++ b/articles/article-template.html
@@ -209,8 +209,8 @@
                         <li class="mb-3"><a href="../index.html#articles" class="text-white text-decoration-none"><i class="bi bi-file-text me-2"></i><span data-i18n="navbar.articles">Articoli</span></a></li>
                         <li class="mb-3"><a href="../index.html#educational-materials" class="text-white text-decoration-none"><i class="bi bi-file-earmark-arrow-down me-2"></i><span data-i18n="educationalMaterials.title">Materiale Didattico</span></a></li>
                         <li class="mb-3"><a href="../index.html#newsletter" class="text-white text-decoration-none"><i class="bi bi-envelope me-2"></i><span data-i18n="navbar.newsletter">Newsletter</span></a></li>
-                        <li class="mb-3"><a href="#" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Privacy Policy"><i class="bi bi-shield-lock me-2"></i><span data-i18n="footer.privacyPolicy">Privacy Policy</span></a></li>
-                        <li class="mb-3"><a href="#" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Cookie Policy"><i class="bi bi-cookie me-2"></i><span data-i18n="footer.cookiePolicy">Cookie Policy</span></a></li>
+                        <li class="mb-3"><a href="https://www.iubenda.com/privacy-policy/" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Privacy Policy"><i class="bi bi-shield-lock me-2"></i><span data-i18n="footer.privacyPolicy">Privacy Policy</span></a></li>
+                        <li class="mb-3"><a href="https://www.iubenda.com/privacy-policy/cookie-policy" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Cookie Policy"><i class="bi bi-cookie me-2"></i><span data-i18n="footer.cookiePolicy">Cookie Policy</span></a></li>
                     </ul>
                 </div>
                 <div class="col-md-4">

--- a/articles/credit-cards.html
+++ b/articles/credit-cards.html
@@ -269,8 +269,8 @@
                         <li class="mb-3"><a href="../index.html#articles" class="text-white text-decoration-none"><i class="bi bi-file-text me-2"></i><span data-i18n="navbar.articles">Articoli</span></a></li>
                         <li class="mb-3"><a href="../index.html#educational-materials" class="text-white text-decoration-none"><i class="bi bi-file-earmark-arrow-down me-2"></i><span data-i18n="educationalMaterials.title">Materiale Didattico</span></a></li>
                         <li class="mb-3"><a href="../index.html#newsletter" class="text-white text-decoration-none"><i class="bi bi-envelope me-2"></i><span data-i18n="navbar.newsletter">Newsletter</span></a></li>
-                        <li class="mb-3"><a href="#" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Privacy Policy"><i class="bi bi-shield-lock me-2"></i><span data-i18n="footer.privacyPolicy">Privacy Policy</span></a></li>
-                        <li class="mb-3"><a href="#" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Cookie Policy"><i class="bi bi-cookie me-2"></i><span data-i18n="footer.cookiePolicy">Cookie Policy</span></a></li>
+                        <li class="mb-3"><a href="https://www.iubenda.com/privacy-policy/" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Privacy Policy"><i class="bi bi-shield-lock me-2"></i><span data-i18n="footer.privacyPolicy">Privacy Policy</span></a></li>
+                        <li class="mb-3"><a href="https://www.iubenda.com/privacy-policy/cookie-policy" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Cookie Policy"><i class="bi bi-cookie me-2"></i><span data-i18n="footer.cookiePolicy">Cookie Policy</span></a></li>
                     </ul>
                 </div>
                 <div class="col-md-4">

--- a/articles/duolingo-case.html
+++ b/articles/duolingo-case.html
@@ -310,8 +310,8 @@
                         <li class="mb-3"><a href="../index.html#articles" class="text-white text-decoration-none"><i class="bi bi-file-text me-2"></i><span data-i18n="navbar.articles">Articoli</span></a></li>
                         <li class="mb-3"><a href="../index.html#educational-materials" class="text-white text-decoration-none"><i class="bi bi-file-earmark-arrow-down me-2"></i><span data-i18n="educationalMaterials.title">Materiale Didattico</span></a></li>
                         <li class="mb-3"><a href="../index.html#newsletter" class="text-white text-decoration-none"><i class="bi bi-envelope me-2"></i><span data-i18n="navbar.newsletter">Newsletter</span></a></li>
-                        <li class="mb-3"><a href="#" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Privacy Policy"><i class="bi bi-shield-lock me-2"></i><span data-i18n="footer.privacyPolicy">Privacy Policy</span></a></li>
-                        <li class="mb-3"><a href="#" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Cookie Policy"><i class="bi bi-cookie me-2"></i><span data-i18n="footer.cookiePolicy">Cookie Policy</span></a></li>
+                        <li class="mb-3"><a href="https://www.iubenda.com/privacy-policy/" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Privacy Policy"><i class="bi bi-shield-lock me-2"></i><span data-i18n="footer.privacyPolicy">Privacy Policy</span></a></li>
+                        <li class="mb-3"><a href="https://www.iubenda.com/privacy-policy/cookie-policy" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Cookie Policy"><i class="bi bi-cookie me-2"></i><span data-i18n="footer.cookiePolicy">Cookie Policy</span></a></li>
                     </ul>
                 </div>
                 <div class="col-md-4">

--- a/articles/marketing-glossary.html
+++ b/articles/marketing-glossary.html
@@ -443,8 +443,8 @@
                         <li class="mb-3"><a href="../index.html#articles" class="text-white text-decoration-none"><i class="bi bi-file-text me-2"></i><span data-i18n="navbar.articles">Articoli</span></a></li>
                         <li class="mb-3"><a href="../index.html#educational-materials" class="text-white text-decoration-none"><i class="bi bi-file-earmark-arrow-down me-2"></i><span data-i18n="educationalMaterials.title">Materiale Didattico</span></a></li>
                         <li class="mb-3"><a href="../index.html#newsletter" class="text-white text-decoration-none"><i class="bi bi-envelope me-2"></i><span data-i18n="navbar.newsletter">Newsletter</span></a></li>
-                        <li class="mb-3"><a href="#" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Privacy Policy"><i class="bi bi-shield-lock me-2"></i><span data-i18n="footer.privacyPolicy">Privacy Policy</span></a></li>
-                        <li class="mb-3"><a href="#" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Cookie Policy"><i class="bi bi-cookie me-2"></i><span data-i18n="footer.cookiePolicy">Cookie Policy</span></a></li>
+                        <li class="mb-3"><a href="https://www.iubenda.com/privacy-policy/" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Privacy Policy"><i class="bi bi-shield-lock me-2"></i><span data-i18n="footer.privacyPolicy">Privacy Policy</span></a></li>
+                        <li class="mb-3"><a href="https://www.iubenda.com/privacy-policy/cookie-policy" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Cookie Policy"><i class="bi bi-cookie me-2"></i><span data-i18n="footer.cookiePolicy">Cookie Policy</span></a></li>
                     </ul>
                 </div>
                 <div class="col-md-4">

--- a/index.html
+++ b/index.html
@@ -527,8 +527,8 @@
                         <li class="mb-3"><a href="#articles" class="text-white text-decoration-none"><i class="bi bi-file-text me-2"></i><span data-i18n="navbar.articles">Articoli</span></a></li>
                         <li class="mb-3"><a href="#educational-materials" class="text-white text-decoration-none"><i class="bi bi-file-earmark-arrow-down me-2"></i><span data-i18n="educationalMaterials.title">Materiale Didattico</span></a></li>
                         <li class="mb-3"><a href="#newsletter" class="text-white text-decoration-none"><i class="bi bi-envelope me-2"></i><span data-i18n="navbar.newsletter">Newsletter</span></a></li>
-                        <li class="mb-3"><a href="#" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Privacy Policy"><i class="bi bi-shield-lock me-2"></i><span data-i18n="footer.privacyPolicy">Privacy Policy</span></a></li>
-                        <li class="mb-3"><a href="#" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Cookie Policy"><i class="bi bi-cookie me-2"></i><span data-i18n="footer.cookiePolicy">Cookie Policy</span></a></li>
+                        <li class="mb-3"><a href="https://www.iubenda.com/privacy-policy/" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Privacy Policy"><i class="bi bi-shield-lock me-2"></i><span data-i18n="footer.privacyPolicy">Privacy Policy</span></a></li>
+                        <li class="mb-3"><a href="https://www.iubenda.com/privacy-policy/cookie-policy" class="text-white text-decoration-none iubenda-nostyle no-brand iubenda-embed iubenda-noiframe" title="Cookie Policy"><i class="bi bi-cookie me-2"></i><span data-i18n="footer.cookiePolicy">Cookie Policy</span></a></li>
                     </ul>
                 </div>
                 <div class="col-md-4">


### PR DESCRIPTION
## Summary
- add fallback Iubenda links in `index.html`
- ensure privacy and cookie policy links work without JS in article pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68559168f818832e9638d03ff90aacf2