### PR TITLE
Add localized 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title data-i18n="notFound.title">Pagina non trovata</title>
+    <link href="css/bootstrap.min.css" rel="stylesheet">
+    <link href="css/style.css" rel="stylesheet">
+</head>
+<body class="d-flex flex-column justify-content-center align-items-center" style="height:100vh;">
+    <div class="text-center">
+        <h1 data-i18n="notFound.title">Pagina non trovata</h1>
+        <p data-i18n="notFound.message">Spiacenti, la pagina che cerchi non esiste.</p>
+        <a href="index.html" class="btn btn-primary" data-i18n="notFound.back">Torna alla home</a>
+    </div>
+    <script src="js/bootstrap.bundle.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/i18next@21.6.10/i18next.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/i18next-http-backend@1.3.2/i18nextHttpBackend.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/i18next-browser-languagedetector@6.1.3/i18nextBrowserLanguageDetector.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jquery-i18next@1.2.1/jquery-i18next.min.js"></script>
+    <script src="js/i18n.js"></script>
+</body>
+</html>

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -71,6 +71,11 @@
   },
   "backToTop": "Back to Top",
   "readingTime": "Reading time: {{time}} min",
+  "notFound": {
+    "title": "Page Not Found",
+    "message": "Sorry, the page you are looking for doesn't exist.",
+    "back": "Go back to the homepage"
+  },
   "cards": {
     "creditCards": {
       "title": "Credit Cards",

--- a/locales/it/translation.json
+++ b/locales/it/translation.json
@@ -71,6 +71,11 @@
   },
   "backToTop": "Torna in cima",
   "readingTime": "Tempo di lettura: {{time}} min",
+  "notFound": {
+    "title": "Pagina non trovata",
+    "message": "Spiacenti, la pagina che cerchi non esiste.",
+    "back": "Torna alla home"
+  },
   "cards": {
     "creditCards": {
       "title": "Carte di Credito",


### PR DESCRIPTION
## Summary
- create `404.html` with links back to the homepage
- add translations for the 404 page in Italian and English

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685595276cf4832e8ae0b7eb98c48b1f