### PR TITLE
Add recommended badge to all article cards

### DIFF
--- a/js/custom.js
+++ b/js/custom.js
@@ -377,6 +377,19 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     };
 
+    const updateRecommendedBadges = (scope = document) => {
+        const cards = scope.querySelectorAll('.card[data-recommended="true"]');
+        cards.forEach(card => {
+            if (!card.querySelector('.card-badge-recommended')) {
+                const badge = document.createElement('div');
+                badge.className = 'card-badge card-badge-recommended';
+                badge.setAttribute('data-i18n', 'featuredArticles.recommended');
+                badge.textContent = (typeof i18next !== 'undefined') ? i18next.t('featuredArticles.recommended') : 'Consigliato';
+                card.prepend(badge);
+            }
+        });
+    };
+
     const updateNewBadges = (scope = document) => {
         const now = new Date();
         const twoWeeksMs = 14 * 24 * 60 * 60 * 1000;
@@ -442,6 +455,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     updateArticleReadingTime();
     updateCardReadingTimes();
+    updateRecommendedBadges();
     updateNewBadges();
     populateFeaturedArticles();
 });


### PR DESCRIPTION
## Summary
- add function to insert "Consigliato" badge for cards flagged as recommended
- call the function when the page loads

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855c497ac40832eb3478ba3bccad048