### PR TITLE
Fix reading time recalculation

### DIFF
--- a/js/custom.js
+++ b/js/custom.js
@@ -448,6 +448,11 @@
         animateCards();
     };
 
+    document.addEventListener('localized', () => {
+        updateArticleReadingTime();
+        updateCardReadingTimes();
+    });
+
     updateArticleReadingTime();
     updateCardReadingTimes();
     updateRecommendedBadges();

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -215,6 +215,9 @@
           // Apply translations
           $('body').localize();
 
+          // Notify listeners that localization finished
+          document.dispatchEvent(new CustomEvent('localized'));
+
           // Clear the timeout since localization completed normally
           clearTimeout(localizationTimeout);
 


### PR DESCRIPTION
## Summary
- trigger a `localized` event after translations finish
- recalculate reading times when localization completes

## Testing
- `node -c js/custom.js`


------
https://chatgpt.com/codex/tasks/task_e_6855f3a0e4ac832e8ae332ca60a762b2