### PR TITLE
Fix reading time badges

### DIFF
--- a/articles/ab-test.html
+++ b/articles/ab-test.html
@@ -217,7 +217,7 @@
             <p class="lead mb-4" data-i18n="articles.abTest.subtitle">Quando l'indecisione diventa una strategia di marketing (e funziona pure!)</p>
             <div class="article-meta">
                 <span><i class="bi bi-calendar me-2"></i> <span class="article-date">20/06/2025</span></span>
-                <span class="mx-3"><i class="bi bi-clock me-2"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "0"}'>Tempo di lettura: 0 min</span></span>
+                <span class="mx-3"><i class="bi bi-clock me-2"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "1"}'>Tempo di lettura: 1 min</span></span>
             </div>
         </div>
     </header>

--- a/articles/aida-model.html
+++ b/articles/aida-model.html
@@ -236,7 +236,7 @@
             <p class="lead mb-4" data-i18n="articles.aidaModel.subtitle">La formula segreta per vendere qualsiasi cosa (anche a tua suocera)</p>
             <div class="article-meta">
                 <span><i class="bi bi-calendar me-2"></i> <span class="article-date">20/06/2025</span></span>
-                <span class="mx-3"><i class="bi bi-clock me-2"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "0"}'>Tempo di lettura: 0 min</span></span>
+                <span class="mx-3"><i class="bi bi-clock me-2"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "2"}'>Tempo di lettura: 2 min</span></span>
             </div>
         </div>
     </header>

--- a/articles/article-template.html
+++ b/articles/article-template.html
@@ -127,7 +127,7 @@
             <p class="lead mb-4" data-i18n="articleSubtitle">Sottotitolo dell'articolo</p>
             <div class="article-meta">
                 <span><i class="bi bi-calendar me-2"></i> <span class="article-date">20/06/2025</span></span>
-                <span class="mx-3"><i class="bi bi-clock me-2"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "0"}'>Tempo di lettura: 0 min</span></span>
+                <span class="mx-3"><i class="bi bi-clock me-2"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "1"}'>Tempo di lettura: 1 min</span></span>
             </div>
         </div>
     </header>

--- a/articles/credit-cards.html
+++ b/articles/credit-cards.html
@@ -149,7 +149,7 @@
             <p class="lead mb-4" data-i18n="articles.creditCards.subtitle">La tua relazione tossica preferita: tu, la tua carta di credito e il tuo conto in banca!</p>
             <div class="article-meta">
                 <span><i class="bi bi-calendar me-2"></i> <span class="article-date">20/06/2025</span></span>
-                <span class="mx-3"><i class="bi bi-clock me-2"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "0"}'>Tempo di lettura: 0 min</span></span>
+                <span class="mx-3"><i class="bi bi-clock me-2"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "1"}'>Tempo di lettura: 1 min</span></span>
             </div>
         </div>
     </header>

--- a/articles/duolingo-case.html
+++ b/articles/duolingo-case.html
@@ -163,7 +163,7 @@
             <p class="lead mb-4" data-i18n="articles.duolingoCase.subtitle">Come un gufo verde ha conquistato il mondo (e perché dovresti prendere appunti)</p>
             <div class="article-meta">
                 <span><i class="bi bi-calendar me-2"></i> <span class="article-date">20/06/2025</span></span>
-                <span class="mx-3"><i class="bi bi-clock me-2"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "0"}'>Tempo di lettura: 0 min</span></span>
+                <span class="mx-3"><i class="bi bi-clock me-2"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "1"}'>Tempo di lettura: 1 min</span></span>
             </div>
         </div>
     </header>

--- a/articles/marketing-glossary.html
+++ b/articles/marketing-glossary.html
@@ -198,7 +198,7 @@
             <p class="lead mb-4" data-i18n="articles.marketingGlossary.subtitle">Perché fingere di capire i termini di marketing quando puoi davvero impararli (e fare la figura dell'esperto)</p>
             <div class="article-meta">
                 <span><i class="bi bi-calendar me-2"></i> <span class="article-date">20/06/2025</span></span>
-                <span class="mx-3"><i class="bi bi-clock me-2"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "0"}'>Tempo di lettura: 0 min</span></span>
+                <span class="mx-3"><i class="bi bi-clock me-2"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "1"}'>Tempo di lettura: 1 min</span></span>
             </div>
         </div>
     </header>

--- a/index.html
+++ b/index.html
@@ -455,14 +455,14 @@ h1, h2, h3, h4, h5, h6 {
             <div class="row">
                 <!-- Credit Cards Article -->
                 <div class="col-md-6 col-lg-4 mb-4 px-3">
-                    <div class="card h-100" data-pubdate="20/06/2025">
+                    <div class="card h-100" data-pubdate="20/06/2025" data-reading-time="1">
                         <div class="card-badge card-badge-recommended" data-i18n="featuredArticles.recommended">Consigliato</div>
                         <img src="images/placeholder.jpg" class="card-img-top" alt="Credit Cards Article" loading="lazy">
                         <div class="card-body">
                             <span class="badge bg-success mb-3" data-i18n="categories.finance">Finanza</span>
                             <h5 class="card-title" data-i18n="cards.creditCards.title">Credit Cards</h5>
                             <p class="card-text" data-i18n="cards.creditCards.description">Scopri tutto sulle carte di credito: vantaggi, svantaggi e come scegliere quella più adatta alle tue esigenze.</p>
-                            <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "0"}'>Tempo di lettura: 0 min</span></p>
+                            <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "1"}'>Tempo di lettura: 1 min</span></p>
                                     <p class="text-muted small"><i class="bi bi-calendar me-1"></i> <span class="article-date">20/06/2025</span></p>
                         </div>
                         <div class="card-footer bg-white border-0">
@@ -473,13 +473,14 @@ h1, h2, h3, h4, h5, h6 {
 
                 <!-- Duolingo Case Study Article -->
                 <div class="col-md-6 col-lg-4 mb-4 px-3">
-                    <div class="card h-100" data-pubdate="20/06/2025">
+                    <div class="card h-100" data-pubdate="20/06/2025" data-reading-time="1">
+                        <div class="card-badge card-badge-new" data-i18n="featuredArticles.new">Nuovo</div>
                         <img src="images/duolingo-case-study.webp" class="card-img-top" alt="Duolingo Case Study Article" loading="lazy">
                         <div class="card-body">
                             <span class="badge bg-primary mb-3" data-i18n="categories.marketing">Marketing</span>
                             <h5 class="card-title" data-i18n="cards.duolingoCase.title">Duolingo Case Study</h5>
                             <p class="card-text" data-i18n="cards.duolingoCase.description">Un'analisi approfondita della strategia di marketing di Duolingo e come ha rivoluzionato l'apprendimento delle lingue.</p>
-                            <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "0"}'>Tempo di lettura: 0 min</span></p>
+                            <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "1"}'>Tempo di lettura: 1 min</span></p>
                                     <p class="text-muted small"><i class="bi bi-calendar me-1"></i> <span class="article-date">20/06/2025</span></p>
                         </div>
                         <div class="card-footer bg-white border-0">
@@ -490,14 +491,14 @@ h1, h2, h3, h4, h5, h6 {
 
                 <!-- Marketing Glossary Article -->
                 <div class="col-md-6 col-lg-4 mb-4 px-3">
-                    <div class="card h-100" data-pubdate="20/06/2025">
+                    <div class="card h-100" data-pubdate="20/06/2025" data-reading-time="1">
                         <div class="card-badge card-badge-recommended" data-i18n="featuredArticles.recommended">Consigliato</div>
                         <img src="images/placeholder.jpg" class="card-img-top" alt="Marketing Glossary Article" loading="lazy">
                         <div class="card-body">
                             <span class="badge bg-primary mb-3" data-i18n="categories.marketing">Marketing</span>
                             <h5 class="card-title" data-i18n="cards.marketingGlossary.title">Marketing Glossary</h5>
                             <p class="card-text" data-i18n="cards.marketingGlossary.description">Un glossario completo dei termini di marketing essenziali per professionisti e principianti.</p>
-                            <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "0"}'>Tempo di lettura: 0 min</span></p>
+                            <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "1"}'>Tempo di lettura: 1 min</span></p>
                                     <p class="text-muted small"><i class="bi bi-calendar me-1"></i> <span class="article-date">20/06/2025</span></p>
                         </div>
                         <div class="card-footer bg-white border-0">
@@ -609,13 +610,14 @@ h1, h2, h3, h4, h5, h6 {
                     <div class="row">
                         <!-- Credit Cards Article -->
                         <div class="col-md-6 col-lg-4 mb-4 px-3">
-                            <div class="card h-100" data-pubdate="20/06/2025" data-recommended="true">
+                            <div class="card h-100" data-pubdate="20/06/2025" data-recommended="true" data-reading-time="1">
+                                <div class="card-badge card-badge-recommended" data-i18n="featuredArticles.recommended">Consigliato</div>
                                 <img src="images/placeholder.jpg" class="card-img-top" alt="Credit Cards Article" loading="lazy">
                                 <div class="card-body">
                                     <span class="badge bg-success mb-3" data-i18n="categories.finance">Finanza</span>
                                     <h5 class="card-title" data-i18n="cards.creditCards.title">Credit Cards</h5>
                                     <p class="card-text" data-i18n="cards.creditCards.description">Scopri tutto sulle carte di credito: vantaggi, svantaggi e come scegliere quella più adatta alle tue esigenze.</p>
-                            <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "0"}'>Tempo di lettura: 0 min</span></p>
+                            <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "1"}'>Tempo di lettura: 1 min</span></p>
                                     <p class="text-muted small"><i class="bi bi-calendar me-1"></i> <span class="article-date">20/06/2025</span></p>
                                 </div>
                                 <div class="card-footer bg-white border-0">
@@ -626,13 +628,14 @@ h1, h2, h3, h4, h5, h6 {
 
                         <!-- Duolingo Case Study Article -->
                         <div class="col-md-6 col-lg-4 mb-4 px-3">
-                            <div class="card h-100" data-pubdate="20/06/2025">
+                            <div class="card h-100" data-pubdate="20/06/2025" data-reading-time="1">
+                                <div class="card-badge card-badge-new" data-i18n="featuredArticles.new">Nuovo</div>
                                 <img src="images/duolingo-case-study.webp" class="card-img-top" alt="Duolingo Case Study Article" loading="lazy">
                                 <div class="card-body">
                                     <span class="badge bg-primary mb-3" data-i18n="categories.marketing">Marketing</span>
                                     <h5 class="card-title" data-i18n="cards.duolingoCase.title">Duolingo Case Study</h5>
                                     <p class="card-text" data-i18n="cards.duolingoCase.description">Un'analisi approfondita della strategia di marketing di Duolingo e come ha rivoluzionato l'apprendimento delle lingue.</p>
-                            <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "0"}'>Tempo di lettura: 0 min</span></p>
+                            <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "1"}'>Tempo di lettura: 1 min</span></p>
                                     <p class="text-muted small"><i class="bi bi-calendar me-1"></i> <span class="article-date">20/06/2025</span></p>
                                 </div>
                                 <div class="card-footer bg-white border-0">
@@ -643,13 +646,14 @@ h1, h2, h3, h4, h5, h6 {
 
                         <!-- Marketing Glossary Article -->
                         <div class="col-md-6 col-lg-4 mb-4 px-3">
-                            <div class="card h-100" data-pubdate="20/06/2025" data-recommended="true">
+                            <div class="card h-100" data-pubdate="20/06/2025" data-recommended="true" data-reading-time="1">
+                                <div class="card-badge card-badge-recommended" data-i18n="featuredArticles.recommended">Consigliato</div>
                                 <img src="images/placeholder.jpg" class="card-img-top" alt="Marketing Glossary Article">
                                 <div class="card-body">
                                     <span class="badge bg-primary mb-3" data-i18n="categories.marketing">Marketing</span>
                                     <h5 class="card-title" data-i18n="cards.marketingGlossary.title">Marketing Glossary</h5>
                                     <p class="card-text" data-i18n="cards.marketingGlossary.description">Un glossario completo dei termini di marketing essenziali per professionisti e principianti.</p>
-                            <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "0"}'>Tempo di lettura: 0 min</span></p>
+                            <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "1"}'>Tempo di lettura: 1 min</span></p>
                                     <p class="text-muted small"><i class="bi bi-calendar me-1"></i> <span class="article-date">20/06/2025</span></p>
                                 </div>
                                 <div class="card-footer bg-white border-0">
@@ -661,13 +665,14 @@ h1, h2, h3, h4, h5, h6 {
                         <!-- AB Test Article -->
                         <!-- AB Test Article -->
                         <div class="col-md-6 col-lg-4 mb-4 px-3">
-                            <div class="card h-100 position-relative" data-pubdate="20/06/2025">
+                            <div class="card h-100 position-relative" data-pubdate="20/06/2025" data-reading-time="1">
+                                <div class="card-badge card-badge-new" data-i18n="featuredArticles.new">Nuovo</div>
                                 <img src="images/placeholder.jpg" class="card-img-top" alt="AB Test Article">
                                 <div class="card-body">
                                     <span class="badge bg-primary mb-3" data-i18n="categories.marketing">Marketing</span>
                                     <h5 class="card-title" data-i18n="cards.abTest.title">AB Test</h5>
                                     <p class="card-text" data-i18n="cards.abTest.description">Guida completa ai test A/B: come implementarli, analizzare i risultati e ottimizzare le conversioni del tuo sito web.</p>
-                                    <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "0"}'>Tempo di lettura: 0 min</span></p>
+                                    <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "1"}'>Tempo di lettura: 1 min</span></p>
                                     <p class="text-muted small"><i class="bi bi-calendar me-1"></i> <span class="article-date">20/06/2025</span></p>
                                 </div>
                                 <div class="card-footer bg-white border-0">
@@ -678,13 +683,14 @@ h1, h2, h3, h4, h5, h6 {
 
                         <!-- AIDA Model Article -->
                         <div class="col-md-6 col-lg-4 mb-4 px-3">
-                            <div class="card h-100" data-pubdate="20/06/2025">
+                            <div class="card h-100" data-pubdate="20/06/2025" data-reading-time="2">
+                                <div class="card-badge card-badge-new" data-i18n="featuredArticles.new">Nuovo</div>
                                 <img src="images/placeholder.jpg" class="card-img-top" alt="AIDA Model Article">
                                 <div class="card-body">
                                     <span class="badge bg-primary mb-3" data-i18n="categories.marketing">Marketing</span>
                                     <h5 class="card-title" data-i18n="cards.aidaModel.title">AIDA Model</h5>
                                     <p class="card-text" data-i18n="cards.aidaModel.description">Esplora il modello AIDA (Attenzione, Interesse, Desiderio, Azione) e come applicarlo efficacemente nelle tue strategie di marketing.</p>
-                                    <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "0"}'>Tempo di lettura: 0 min</span></p>
+                                    <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "2"}'>Tempo di lettura: 2 min</span></p>
                                     <p class="text-muted small"><i class="bi bi-calendar me-1"></i> <span class="article-date">20/06/2025</span></p>
                                 </div>
                                 <div class="card-footer bg-white border-0">
@@ -700,13 +706,14 @@ h1, h2, h3, h4, h5, h6 {
                     <div class="row">
                         <!-- Duolingo Case Study Article -->
                         <div class="col-md-6 col-lg-4 mb-4 px-3">
-                            <div class="card h-100" data-pubdate="20/06/2025">
+                            <div class="card h-100" data-pubdate="20/06/2025" data-reading-time="1">
+                                <div class="card-badge card-badge-new" data-i18n="featuredArticles.new">Nuovo</div>
                                 <img src="images/duolingo-case-study.webp" class="card-img-top" alt="Duolingo Case Study Article">
                                 <div class="card-body">
                                     <span class="badge bg-primary mb-3" data-i18n="categories.marketing">Marketing</span>
                                     <h5 class="card-title" data-i18n="cards.duolingoCase.title">Duolingo Case Study</h5>
                                     <p class="card-text" data-i18n="cards.duolingoCase.description">Un'analisi approfondita della strategia di marketing di Duolingo e come ha rivoluzionato l'apprendimento delle lingue.</p>
-                            <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "0"}'>Tempo di lettura: 0 min</span></p>
+                            <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "1"}'>Tempo di lettura: 1 min</span></p>
                                     <p class="text-muted small"><i class="bi bi-calendar me-1"></i> <span class="article-date">20/06/2025</span></p>
                                 </div>
                                 <div class="card-footer bg-white border-0">
@@ -717,13 +724,14 @@ h1, h2, h3, h4, h5, h6 {
 
                         <!-- Marketing Glossary Article -->
                         <div class="col-md-6 col-lg-4 mb-4 px-3">
-                            <div class="card h-100" data-pubdate="20/06/2025" data-recommended="true">
+                            <div class="card h-100" data-pubdate="20/06/2025" data-recommended="true" data-reading-time="1">
+                                <div class="card-badge card-badge-recommended" data-i18n="featuredArticles.recommended">Consigliato</div>
                                 <img src="images/placeholder.jpg" class="card-img-top" alt="Marketing Glossary Article">
                                 <div class="card-body">
                                     <span class="badge bg-primary mb-3" data-i18n="categories.marketing">Marketing</span>
                                     <h5 class="card-title" data-i18n="cards.marketingGlossary.title">Marketing Glossary</h5>
                                     <p class="card-text" data-i18n="cards.marketingGlossary.description">Un glossario completo dei termini di marketing essenziali per professionisti e principianti.</p>
-                            <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "0"}'>Tempo di lettura: 0 min</span></p>
+                            <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "1"}'>Tempo di lettura: 1 min</span></p>
                                     <p class="text-muted small"><i class="bi bi-calendar me-1"></i> <span class="article-date">20/06/2025</span></p>
                                 </div>
                                 <div class="card-footer bg-white border-0">
@@ -734,13 +742,14 @@ h1, h2, h3, h4, h5, h6 {
 
                         <!-- AB Test Article -->
                         <div class="col-md-6 col-lg-4 mb-4 px-3">
-                            <div class="card h-100" data-pubdate="20/06/2025">
+                            <div class="card h-100" data-pubdate="20/06/2025" data-reading-time="1">
+                                <div class="card-badge card-badge-new" data-i18n="featuredArticles.new">Nuovo</div>
                                 <img src="images/placeholder.jpg" class="card-img-top" alt="AB Test Article">
                                 <div class="card-body">
                                     <span class="badge bg-primary mb-3" data-i18n="categories.marketing">Marketing</span>
                                     <h5 class="card-title" data-i18n="cards.abTest.title">AB Test</h5>
                                     <p class="card-text" data-i18n="cards.abTest.description">Guida completa ai test A/B: come implementarli, analizzare i risultati e ottimizzare le conversioni del tuo sito web.</p>
-                                    <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "0"}'>Tempo di lettura: 0 min</span></p>
+                                    <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "1"}'>Tempo di lettura: 1 min</span></p>
                                     <p class="text-muted small"><i class="bi bi-calendar me-1"></i> <span class="article-date">20/06/2025</span></p>
                                 </div>
                                 <div class="card-footer bg-white border-0">
@@ -751,13 +760,14 @@ h1, h2, h3, h4, h5, h6 {
 
                         <!-- AIDA Model Article -->
                         <div class="col-md-6 col-lg-4 mb-4 px-3">
-                            <div class="card h-100" data-pubdate="20/06/2025">
+                            <div class="card h-100" data-pubdate="20/06/2025" data-reading-time="2">
+                                <div class="card-badge card-badge-new" data-i18n="featuredArticles.new">Nuovo</div>
                                 <img src="images/placeholder.jpg" class="card-img-top" alt="AIDA Model Article">
                                 <div class="card-body">
                                     <span class="badge bg-primary mb-3" data-i18n="categories.marketing">Marketing</span>
                                     <h5 class="card-title" data-i18n="cards.aidaModel.title">AIDA Model</h5>
                                     <p class="card-text" data-i18n="cards.aidaModel.description">Esplora il modello AIDA (Attenzione, Interesse, Desiderio, Azione) e come applicarlo efficacemente nelle tue strategie di marketing.</p>
-                                    <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "0"}'>Tempo di lettura: 0 min</span></p>
+                                    <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "2"}'>Tempo di lettura: 2 min</span></p>
                                     <p class="text-muted small"><i class="bi bi-calendar me-1"></i> <span class="article-date">20/06/2025</span></p>
                                 </div>
                                 <div class="card-footer bg-white border-0">
@@ -773,13 +783,14 @@ h1, h2, h3, h4, h5, h6 {
                     <div class="row">
                         <!-- Credit Cards Article -->
                         <div class="col-md-6 col-lg-4 mb-4 px-3">
-                            <div class="card h-100" data-pubdate="20/06/2025" data-recommended="true">
+                            <div class="card h-100" data-pubdate="20/06/2025" data-recommended="true" data-reading-time="1">
+                                <div class="card-badge card-badge-recommended" data-i18n="featuredArticles.recommended">Consigliato</div>
                                 <img src="images/placeholder.jpg" class="card-img-top" alt="Credit Cards Article">
                                 <div class="card-body">
                                     <span class="badge bg-success mb-3" data-i18n="categories.finance">Finanza</span>
                                     <h5 class="card-title" data-i18n="cards.creditCards.title">Credit Cards</h5>
                                     <p class="card-text" data-i18n="cards.creditCards.description">Scopri tutto sulle carte di credito: vantaggi, svantaggi e come scegliere quella più adatta alle tue esigenze.</p>
-                            <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "0"}'>Tempo di lettura: 0 min</span></p>
+                            <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "1"}'>Tempo di lettura: 1 min</span></p>
                                     <p class="text-muted small"><i class="bi bi-calendar me-1"></i> <span class="article-date">20/06/2025</span></p>
                                 </div>
                                 <div class="card-footer bg-white border-0">

--- a/js/custom.js
+++ b/js/custom.js
@@ -360,9 +360,17 @@
     const updateCardReadingTimes = (scope = document) => {
         const cards = scope.querySelectorAll('.card');
         cards.forEach(card => {
-            const link = card.querySelector('.card-footer a[href]');
             const timeSpan = card.querySelector('.reading-time span');
-            if (link && timeSpan) {
+            if (!timeSpan) return;
+
+            const predefined = card.getAttribute('data-reading-time');
+            if (predefined) {
+                setReadingTime(timeSpan, parseInt(predefined, 10));
+                return;
+            }
+
+            const link = card.querySelector('.card-footer a[href]');
+            if (link) {
                 fetchReadingTime(link.getAttribute('href')).then(minutes => {
                     if (minutes) {
                         setReadingTime(timeSpan, minutes);


### PR DESCRIPTION
## Summary
- show recommended and new badges directly in markup
- prefill reading time for articles
- let `custom.js` use optional data-reading-time attribute

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855f675ae48832eac370a63cfd42cfb