### PR TITLE
Fix auto-population of featured articles

### DIFF
--- a/js/custom.js
+++ b/js/custom.js
@@ -429,6 +429,13 @@
         animateCards();
     };
 
+    // Initial population in case the 'localized' event is not triggered
+    updateArticleReadingTime();
+    updateCardReadingTimes();
+    updateRecommendedBadges();
+    updateNewBadges();
+    populateFeaturedArticles();
+
     document.addEventListener('localized', () => {
         updateArticleReadingTime();
         updateCardReadingTimes();


### PR DESCRIPTION
## Summary
- ensure featured articles populate on initial load even without `localized` event

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685600145aac832e99e1b3189f6a29d5