### PR TITLE
Fix featured article filtering

### DIFF
--- a/js/custom.js
+++ b/js/custom.js
@@ -395,12 +395,17 @@
 
     const populateFeaturedArticles = () => {
         const featuredContainer = document.querySelector('#featured-articles .row');
-        const sourceCards = document.querySelectorAll('#all .card');
+        const sourceCards = document.querySelectorAll('#articles .card');
         if (!featuredContainer || !sourceCards.length) return;
 
         featuredContainer.innerHTML = '';
 
+        const seen = new Set();
         sourceCards.forEach(card => {
+            const link = card.querySelector('a[href]');
+            const href = link ? link.getAttribute('href') : null;
+            if (href && seen.has(href)) return;
+            if (href) seen.add(href);
             const isRecommended = card.getAttribute('data-recommended') === 'true';
             const isNew = card.querySelector('.card-badge-new');
 


### PR DESCRIPTION
## Summary
- include all article cards from the Articles section when populating the featured-articles list
- avoid duplicates when gathering cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685604b67b94832e808973cc22bd52b5