### PR TITLE
Fix endless card reload on localization

### DIFF
--- a/js/custom.js
+++ b/js/custom.js
@@ -479,12 +479,14 @@
     populateFeaturedArticles();
 
     document.addEventListener('localized', () => {
+        // Update dynamic data when translations are applied.
+        // Avoid repopulating the "featured" section here to prevent
+        // a MutationObserver loop that causes cards to continually reload.
         updateArticleReadingTime();
         updateCardReadingTimes();
         fetchCardReadingTimesFromArticles();
         updateRecommendedBadges();
         updateNewBadges();
-        populateFeaturedArticles();
     });
     }
 


### PR DESCRIPTION
## Summary
- prevent featured article container from repopulating after every `localized` event
- add explanation comment in `custom.js`

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_68567718ef64832e8d994febb9d457e6