### PR TITLE
Revamp hero carousel layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -768,3 +768,18 @@ footer a:hover {
     transform: translateY(-5px);
     box-shadow: 0 10px 20px rgba(0, 0, 0, 0.1);
 }
+
+/* Hero Carousel */
+#heroCarousel .hero-slide-img {
+    height: 320px;
+    object-fit: cover;
+}
+#heroCarousel .carousel-caption {
+    background: rgba(0,0,0,0.6);
+    border-radius: 0.5rem;
+    padding: 1rem;
+}
+#heroCarousel .carousel-caption h5 {
+    font-size: 1.25rem;
+    font-weight: 600;
+}

--- a/index.html
+++ b/index.html
@@ -421,6 +421,17 @@ h1, h2, h3, h4, h5, h6 {
         <div class="container">
             <h1 class="display-3 fw-bold mb-3" data-i18n="hero.title">Trasforma le Tue Competenze Digitali</h1>
             <p class="lead mb-4" data-i18n="hero.subtitle">Strategie pratiche, consigli esperti e guide dettagliate su Marketing, Finanza Personale e Programmazione per aiutarti a crescere professionalmente</p>
+            <div id="heroCarousel" class="carousel slide carousel-fade mb-4" data-bs-ride="carousel">
+                <div class="carousel-inner"><!-- slides populated by custom.js --></div>
+                <button class="carousel-control-prev" type="button" data-bs-target="#heroCarousel" data-bs-slide="prev">
+                    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                    <span class="visually-hidden">Previous</span>
+                </button>
+                <button class="carousel-control-next" type="button" data-bs-target="#heroCarousel" data-bs-slide="next">
+                    <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                    <span class="visually-hidden">Next</span>
+                </button>
+            </div>
             <a href="#articles" class="btn btn-primary btn-lg"><i class="bi bi-search me-2"></i><span data-i18n="hero.cta">Scopri i Contenuti Esclusivi</span></a>
         </div>
     </header>
@@ -448,70 +459,6 @@ h1, h2, h3, h4, h5, h6 {
         </div>
     </section>
 
-    <!-- New and Recommended Articles -->
-    <section id="featured-articles" class="py-6">
-        <div class="container">
-            <h2 class="text-center section-title mb-5"><i class="bi bi-star me-2"></i><span data-i18n="featuredArticles.title">Articoli Nuovi e Consigliati</span></h2>
-            <div class="row">
-                <!-- Credit Cards Article -->
-                <div class="col-md-6 col-lg-4 mb-4 px-3">
-                    <div class="card h-100" data-pubdate="20/06/2025" data-reading-time="4">
-                        <div class="card-badge card-badge-recommended" data-i18n="featuredArticles.recommended">Consigliato</div>
-                        <img src="images/placeholder.jpg" class="card-img-top" alt="Credit Cards Article" loading="lazy">
-                        <div class="card-body">
-                            <span class="badge bg-success mb-3" data-i18n="categories.finance">Finanza</span>
-                            <h5 class="card-title" data-i18n="cards.creditCards.title">Credit Cards</h5>
-                            <p class="card-text" data-i18n="cards.creditCards.description">Scopri tutto sulle carte di credito: vantaggi, svantaggi e come scegliere quella più adatta alle tue esigenze.</p>
-                            <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "4"}'>Tempo di lettura: 4 min</span></p>
-                                    <p class="text-muted small"><i class="bi bi-calendar me-1"></i> <span class="article-date">20/06/2025</span></p>
-                                    <p class="text-muted small"><i class="bi bi-person me-1"></i> <span data-i18n="writtenBy" data-i18n-options='{"author": "Crescenzo Sorrentino"}'>Scritto da Crescenzo Sorrentino</span></p>
-                        </div>
-                        <div class="card-footer bg-white border-0">
-                            <a href="articles/credit-cards.html" class="btn btn-outline-success"><i class="bi bi-book me-1"></i> <span data-i18n="featuredArticles.readMore">Leggi di più</span></a>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Duolingo Case Study Article -->
-                <div class="col-md-6 col-lg-4 mb-4 px-3">
-                    <div class="card h-100" data-pubdate="20/06/2025" data-reading-time="5">
-                        <div class="card-badge card-badge-new" data-i18n="featuredArticles.new">Nuovo</div>
-                        <img src="images/duolingo-case-study.webp" class="card-img-top" alt="Duolingo Case Study Article" loading="lazy">
-                        <div class="card-body">
-                            <span class="badge bg-primary mb-3" data-i18n="categories.marketing">Marketing</span>
-                            <h5 class="card-title" data-i18n="cards.duolingoCase.title">Duolingo Case Study</h5>
-                            <p class="card-text" data-i18n="cards.duolingoCase.description">Un'analisi approfondita della strategia di marketing di Duolingo e come ha rivoluzionato l'apprendimento delle lingue.</p>
-                            <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "5"}'>Tempo di lettura: 5 min</span></p>
-                                    <p class="text-muted small"><i class="bi bi-calendar me-1"></i> <span class="article-date">20/06/2025</span></p>
-                                    <p class="text-muted small"><i class="bi bi-person me-1"></i> <span data-i18n="writtenBy" data-i18n-options='{"author": "Crescenzo Sorrentino"}'>Scritto da Crescenzo Sorrentino</span></p>
-                        </div>
-                        <div class="card-footer bg-white border-0">
-                            <a href="articles/duolingo-case.html" class="btn btn-outline-primary"><i class="bi bi-book me-1"></i> <span data-i18n="featuredArticles.readMore">Leggi di più</span></a>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Marketing Glossary Article -->
-                <div class="col-md-6 col-lg-4 mb-4 px-3">
-                    <div class="card h-100" data-pubdate="20/06/2025" data-reading-time="7">
-                        <div class="card-badge card-badge-recommended" data-i18n="featuredArticles.recommended">Consigliato</div>
-                        <img src="images/placeholder.jpg" class="card-img-top" alt="Marketing Glossary Article" loading="lazy">
-                        <div class="card-body">
-                            <span class="badge bg-primary mb-3" data-i18n="categories.marketing">Marketing</span>
-                            <h5 class="card-title" data-i18n="cards.marketingGlossary.title">Marketing Glossary</h5>
-                            <p class="card-text" data-i18n="cards.marketingGlossary.description">Un glossario completo dei termini di marketing essenziali per professionisti e principianti.</p>
-                            <p class="text-muted small reading-time"><i class="bi bi-clock me-1"></i> <span data-i18n="readingTime" data-i18n-options='{"time": "7"}'>Tempo di lettura: 7 min</span></p>
-                                    <p class="text-muted small"><i class="bi bi-calendar me-1"></i> <span class="article-date">20/06/2025</span></p>
-                                    <p class="text-muted small"><i class="bi bi-person me-1"></i> <span data-i18n="writtenBy" data-i18n-options='{"author": "Crescenzo Sorrentino"}'>Scritto da Crescenzo Sorrentino</span></p>
-                        </div>
-                        <div class="card-footer bg-white border-0">
-                            <a href="articles/marketing-glossary.html" class="btn btn-outline-primary"><i class="bi bi-book me-1"></i> <span data-i18n="featuredArticles.readMore">Leggi di più</span></a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
 
     <!-- Newsletter Section -->
     <section id="newsletter" class="py-6 bg-primary text-white">

--- a/js/custom.js
+++ b/js/custom.js
@@ -428,12 +428,12 @@
         });
     };
 
-    const populateFeaturedArticles = () => {
-        const featuredContainer = document.querySelector('#featured-articles .row');
+    const populateHeroCarousel = () => {
+        const carouselInner = document.querySelector('#heroCarousel .carousel-inner');
         const sourceCards = document.querySelectorAll('#articles .card');
-        if (!featuredContainer || !sourceCards.length) return;
+        if (!carouselInner || !sourceCards.length) return;
 
-        featuredContainer.innerHTML = '';
+        carouselInner.innerHTML = '';
 
         const seen = new Set();
         sourceCards.forEach(card => {
@@ -441,33 +441,67 @@
             const href = link ? link.getAttribute('href') : null;
             if (href && seen.has(href)) return;
             if (href) seen.add(href);
+
             const isRecommended = card.getAttribute('data-recommended') === 'true';
             const isNew = card.querySelector('.card-badge-new');
 
             if (isRecommended || isNew) {
-                const clone = card.cloneNode(true);
+                const img = card.querySelector('img.card-img-top');
+                const titleEl = card.querySelector('.card-title');
+                const descEl = card.querySelector('.card-text');
 
-                if (isRecommended && !clone.querySelector('.card-badge-recommended')) {
-                    const badge = document.createElement('div');
-                    badge.className = 'card-badge card-badge-recommended';
-                    badge.setAttribute('data-i18n', 'featuredArticles.recommended');
-                    badge.textContent = (typeof i18next !== 'undefined') ? i18next.t('featuredArticles.recommended') : 'Consigliato';
-                    clone.prepend(badge);
+                const item = document.createElement('div');
+                item.className = 'carousel-item';
+                if (carouselInner.childElementCount === 0) item.classList.add('active');
+
+                if (img) {
+                    const imgClone = img.cloneNode();
+                    imgClone.className = 'd-block w-100 hero-slide-img';
+                    item.appendChild(imgClone);
                 }
 
-                const col = document.createElement('div');
-                col.className = 'col-md-6 col-lg-4 mb-4 px-3';
-                col.appendChild(clone);
-                featuredContainer.appendChild(col);
+                const caption = document.createElement('div');
+                caption.className = 'carousel-caption d-md-block';
+
+                if (isRecommended || isNew) {
+                    const badge = document.createElement('span');
+                    badge.className = `badge ${isRecommended ? 'bg-success' : 'bg-danger'} me-2`;
+                    badge.setAttribute('data-i18n', isRecommended ? 'featuredArticles.recommended' : 'featuredArticles.new');
+                    badge.textContent = (typeof i18next !== 'undefined') ?
+                        i18next.t(isRecommended ? 'featuredArticles.recommended' : 'featuredArticles.new') :
+                        (isRecommended ? 'Consigliato' : 'Nuovo');
+                    caption.appendChild(badge);
+                }
+
+                if (titleEl) {
+                    const h5 = document.createElement('h5');
+                    h5.className = 'fw-bold';
+                    h5.textContent = titleEl.textContent;
+                    caption.appendChild(h5);
+                }
+
+                if (descEl) {
+                    const p = document.createElement('p');
+                    p.className = 'd-none d-sm-block';
+                    p.textContent = descEl.textContent;
+                    caption.appendChild(p);
+                }
+
+                if (href) {
+                    const btn = document.createElement('a');
+                    btn.href = href;
+                    btn.className = 'btn btn-primary';
+                    btn.setAttribute('data-i18n', 'featuredArticles.readMore');
+                    btn.textContent = (typeof i18next !== 'undefined') ? i18next.t('featuredArticles.readMore') : 'Leggi di più';
+                    caption.appendChild(btn);
+                }
+
+                item.appendChild(caption);
+                carouselInner.appendChild(item);
             }
         });
 
-        setButtonColors(featuredContainer);
-        replacePlaceholderImages(featuredContainer);
-        updateCardReadingTimes(featuredContainer);
-        fetchCardReadingTimesFromArticles(featuredContainer);
-        updateNewBadges(featuredContainer);
-        animateCards();
+        replacePlaceholderImages(carouselInner);
     };
 
     // Initial population in case the 'localized' event is not triggered
@@ -476,11 +510,11 @@
     fetchCardReadingTimesFromArticles();
     updateRecommendedBadges();
     updateNewBadges();
-    populateFeaturedArticles();
+    populateHeroCarousel();
 
     document.addEventListener('localized', () => {
         // Update dynamic data when translations are applied.
-        // Avoid repopulating the "featured" section here to prevent
+        // Avoid repopulating the hero carousel here to prevent
         // a MutationObserver loop that causes cards to continually reload.
         updateArticleReadingTime();
         updateCardReadingTimes();


### PR DESCRIPTION
## Summary
- restyle hero carousel slides by cloning content from articles without using card markup
- add custom styles for hero carousel captions and images
- enable fade transition on the carousel

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6857ffa73ec0832e888c1b5b36959dcb