### PR TITLE
Convert hero to article carousel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -131,6 +131,12 @@ h1, h2, h3, h4, h5, h6 {
     margin: 0 auto;
 }
 
+.hero-carousel .carousel-caption {
+    background: rgba(0, 0, 0, 0.5);
+    border-radius: 12px;
+    padding: 1rem;
+}
+
 .hero-carousel .carousel-item img {
     border-radius: 12px;
     height: 400px;

--- a/index.html
+++ b/index.html
@@ -419,10 +419,7 @@ h1, h2, h3, h4, h5, h6 {
     <!-- Hero Section -->
     <section id="hero" class="hero-section text-white text-center py-5">
         <div class="container">
-            <h1 class="display-4 fw-bold mb-3" data-i18n="hero.title">Trasforma le Tue Competenze Digitali</h1>
-            <p class="lead mb-4" data-i18n="hero.subtitle">Strategie pratiche, consigli esperti e guide dettagliate su Marketing, Finanza Personale e Programmazione per aiutarti a crescere professionalmente</p>
-            <a href="#articles" class="btn btn-primary btn-lg d-inline-flex align-items-center"><i class="bi bi-search me-2"></i><span data-i18n="hero.cta">Scopri i Contenuti Esclusivi</span></a>
-            <div id="heroCarousel" class="carousel slide hero-carousel mt-4" data-bs-ride="carousel">
+            <div id="heroCarousel" class="carousel slide hero-carousel" data-bs-ride="carousel">
                 <div class="carousel-indicators"></div>
                 <div class="carousel-inner"></div>
                 <button class="carousel-control-prev" type="button" data-bs-target="#heroCarousel" data-bs-slide="prev">

--- a/js/custom.js
+++ b/js/custom.js
@@ -453,6 +453,9 @@
                 const img = card.querySelector('img.card-img-top');
                 const titleEl = card.querySelector('.card-title');
                 const descEl = card.querySelector('.card-text');
+                const readTimeEl = card.querySelector('.reading-time');
+                const dateEl = card.querySelector('.article-date');
+                const authorEl = card.querySelector('[data-i18n="writtenBy"]');
 
                 const item = document.createElement('div');
                 item.className = 'carousel-item';
@@ -489,6 +492,25 @@
                     p.className = 'd-none d-sm-block';
                     p.textContent = descEl.textContent;
                     caption.appendChild(p);
+                }
+
+                if (readTimeEl) {
+                    const rt = readTimeEl.cloneNode(true);
+                    caption.appendChild(rt);
+                }
+
+                if (dateEl) {
+                    const dateClone = document.createElement('p');
+                    dateClone.className = 'text-muted small';
+                    dateClone.innerHTML = `<i class="bi bi-calendar me-1"></i> <span class="article-date">${dateEl.textContent}</span>`;
+                    caption.appendChild(dateClone);
+                }
+
+                if (authorEl) {
+                    const authorClone = document.createElement('p');
+                    authorClone.className = 'text-muted small';
+                    authorClone.innerHTML = `<i class="bi bi-person me-1"></i> ${authorEl.outerHTML}`;
+                    caption.appendChild(authorClone);
                 }
 
                 if (href) {


### PR DESCRIPTION
## Summary
- convert the hero section into a full carousel
- include reading time, date and author inside carousel captions
- add basic styling for carousel captions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685814a4dd68832ebb6ecee695fc496c