### PR TITLE
Add automatic carousel for new and recommended articles

### DIFF
--- a/index.html
+++ b/index.html
@@ -395,6 +395,22 @@ h1, h2, h3, h4, h5, h6 {
         </div>
     </section>
 
+    <!-- Recommended Carousel -->
+    <section id="featured-carousel" class="py-6">
+        <div id="carouselExampleCaptions" class="carousel slide" data-bs-ride="carousel">
+            <div class="carousel-indicators" id="carouselExampleCaptionsIndicators"></div>
+            <div class="carousel-inner" id="carouselExampleCaptionsInner"></div>
+            <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide="prev">
+                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                <span class="visually-hidden">Previous</span>
+            </button>
+            <button class="carousel-control-next" type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide="next">
+                <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                <span class="visually-hidden">Next</span>
+            </button>
+        </div>
+    </section>
+
     <!-- About Me Section -->
     <section id="about" class="py-6 bg-light">
         <div class="container">


### PR DESCRIPTION
## Summary
- add a new Bootstrap carousel on the homepage
- populate this carousel automatically with new or recommended articles
- implement JS helper `populateCaptionsCarousel`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68584ec618a4832eae1615077b050824