### PR TITLE
Add hero carousel comment and toggle visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -363,7 +363,7 @@ h1, h2, h3, h4, h5, h6 {
     </nav>
 
 
-    <!-- Recommended Carousel -->
+    <!-- Hero carousel automatically filled with new or recommended articles -->
     <section id="featured-carousel" class="py-6">
         <div id="carouselExampleCaptions" class="carousel slide" data-bs-ride="carousel">
             <div class="carousel-indicators" id="carouselExampleCaptionsIndicators"></div>

--- a/js/custom.js
+++ b/js/custom.js
@@ -429,15 +429,20 @@
     };
 
 
-    const populateCaptionsCarousel = () => {
+    // Populate the hero carousel with cards marked as new or recommended
+    const populateHeroCarousel = () => {
         const inner = document.getElementById('carouselExampleCaptionsInner');
         const indicators = document.getElementById('carouselExampleCaptionsIndicators');
+        const section = document.getElementById('featured-carousel');
         if (!inner) return;
 
         const sourceCols = Array.from(document.querySelectorAll('#articles .col-md-6.col-lg-4'));
         inner.innerHTML = '';
         if (indicators) indicators.innerHTML = '';
-        if (!sourceCols.length) return;
+        if (!sourceCols.length) {
+            if (section) section.style.display = 'none';
+            return;
+        }
 
         const cards = sourceCols.map(col => {
             const card = col.querySelector('.card');
@@ -465,6 +470,13 @@
 
         const seen = new Set();
         let added = 0;
+        if (!cards.length) {
+            if (section) section.style.display = 'none';
+            return;
+        } else if (section) {
+            section.style.display = '';
+        }
+
         for (const data of cards) {
             if (added >= 3) break;
             if (seen.has(data.href)) continue;
@@ -525,7 +537,7 @@
     fetchCardReadingTimesFromArticles();
     updateRecommendedBadges();
     updateNewBadges();
-    populateCaptionsCarousel();
+    populateHeroCarousel();
 
     document.addEventListener('localized', () => {
         // Update dynamic data when translations are applied.
@@ -535,7 +547,7 @@
         updateRecommendedBadges();
         updateNewBadges();
 
-        populateCaptionsCarousel();
+        populateHeroCarousel();
     });
     }
 


### PR DESCRIPTION
## Summary
- add comment in `index.html` for hero carousel
- rename carousel population function to `populateHeroCarousel`
- hide hero section when no new or recommended posts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685851f72054832e942344ec5ef61025